### PR TITLE
Fix mmk_default constexpr linkage.

### DIFF
--- a/include/mimick/literal.h
+++ b/include/mimick/literal.h
@@ -47,6 +47,9 @@ struct mmk_default {
   static constexpr T value{};
 };
 
+template<typename T>
+constexpr T mmk_default<T>::value;
+
 template <typename T, size_t N>
 struct mmk_default<T[N]> {
   static T value[N];


### PR DESCRIPTION
Precisely what the title says. Follow-up after #6.