### PR TITLE
Fix clear cache trampoline

### DIFF
--- a/src/trampoline.c
+++ b/src/trampoline.c
@@ -83,7 +83,7 @@ plt_fn *create_trampoline(void *ctx, plt_fn *routine)
 # if defined __clang__  // Check for Clang first, it may set __GNUC__ too.
     __clear_cache(map, map + PAGE_SIZE);
 # elif defined __GNUC__
-    __builtin___clear_cache((char *)map, (char *)(map + PAGE_SIZE));
+    __builtin___clear_cache((char *)map, (char *)(map + 2 + trampoline_sz));
 # endif
     return (plt_fn *) (map + 2);
 }

--- a/src/trampoline.c
+++ b/src/trampoline.c
@@ -81,7 +81,7 @@ plt_fn *create_trampoline(void *ctx, plt_fn *routine)
     memcpy(map + 2, mmk_trampoline, trampoline_sz);
     mmk_assert(!mmk_mprotect(map, PAGE_SIZE, PROT_READ | PROT_EXEC));
 # if defined __clang__  // Check for Clang first, it may set __GNUC__ too.
-    __clear_cache(map, map + PAGE_SIZE);
+    __clear_cache(map, map + 2 + trampoline_sz);
 # elif defined __GNUC__
     __builtin___clear_cache((char *)map, (char *)(map + 2 + trampoline_sz));
 # endif


### PR DESCRIPTION
Clears the cache for only the segment used for the trampoline, fixes issue with `aarch64`. @hidmic Let me know if you think I should change this too for the `__clear_cache(map, map + PAGE_SIZE);` part, although it seems reasonable to include it, it is not failing at the moment.

Signed-off-by: Jorge Perez <jjperez@ekumenlabs.com>