### PR TITLE
Suppress cppcheck error for MMK_MANGLE

### DIFF
--- a/include/mimick/mock.h
+++ b/include/mimick/mock.h
@@ -90,6 +90,7 @@ void mmk_reset(mmk_fn fn);
 
 # define MMK_MK_ARG_STR(_, X) #X,
 
+// cppcheck-suppress preprocessorErrorDirective
 # define MMK_MANGLE_(Id, Name) mmkuser_ ## Id ## _ ## Name
 # define MMK_MANGLE(Id, Name) MMK_MANGLE_(Id, Name)
 


### PR DESCRIPTION
This macro was causing false positives when being included in tests with rclcpp_action and rclcpp_lifecycle.

Example failure:
[![Build Status](https://ci.ros2.org/buildStatus/icon?job=ci_windows&build=12161)](https://ci.ros2.org/job/ci_windows/12161/)

Testing `--packages-select rclcpp_action`
* Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=12319)](http://ci.ros2.org/job/ci_linux/12319/)
* Linux-aarch64 [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-aarch64&build=7288)](http://ci.ros2.org/job/ci_linux-aarch64/7288/)
* macOS [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_osx&build=10032)](http://ci.ros2.org/job/ci_osx/10032/)
* Windows [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=12221)](http://ci.ros2.org/job/ci_windows/12221/)

Signed-off-by: Stephen Brawner <brawner@gmail.com>