### PR TITLE
Address unused parameter src warning

### DIFF
--- a/include/mimick/literal.h
+++ b/include/mimick/literal.h
@@ -80,7 +80,7 @@ inline T (& mmk_assign(T (&dst)[N], T * src))[N] {
   return dst;
 }
 
-inline va_list & mmk_assign(va_list & dst, va_list src) {
+inline va_list & mmk_assign(va_list & dst, va_list) {
   // no-op
   return dst;
 }


### PR DESCRIPTION
While preparing a separate repo for patch.hpp, an unused parameter warning popped up for this function.
Signed-off-by: Stephen Brawner <brawner@gmail.com>