### PR TITLE
Update cmake minimum version to 2.8.12

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,7 @@
 # Redistribution and use of this file is allowed according to the terms of the MIT license.
 # For details see the LICENSE file distributed with Mimick.
 
-cmake_minimum_required (VERSION 2.8)
+cmake_minimum_required (VERSION 2.8.12)
 
 project (Mimick C CXX)
 # Default to C++11


### PR DESCRIPTION
This addresses a new deprecation warning with cmake 3.19 (the new version on windows jobs).

Signed-off-by: Stephen Brawner <brawner@gmail.com>