### PR TITLE
Add armv7l as a 32-bit ARM architecture.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,7 +23,7 @@ set (CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} ${MODULE_DIR})
 
 set (I386 "^(i[3-7]|x)86$")
 set (AMD64 "^(x86_|x86-|AMD|amd|x)64$")
-set (ARM32 "^(arm|ARM|A)(32)?$")
+set (ARM32 "^(arm|ARM|A)(32|v7l)?$")
 set (ARM64 "^(arm|ARM|A|aarch|AARCH)64$")
 
 if (CMAKE_GENERATOR_PLATFORM)


### PR DESCRIPTION
Replacement for https://github.com/ros2/Mimick/pull/14.

This adds amv7l as a valid architecture so ROS2 can be built on/for Raspbian.
