### PR TITLE
Fix detection of 64-bit for Visual Studio 2019 and 2022

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -35,7 +35,10 @@ endif ()
 set (MMK_MANGLING "none")
 
 if (MSVC)
-  if (NOT CMAKE_GENERATOR_PLATFORM)
+  # Visual Studio generator version earlier than 2017 (included) default to x86,
+  # after 2019 (included) it defaults to amd64
+  # MSVC_VERSION = 1920 corresponds to Visual Studio 2019
+  if (NOT CMAKE_GENERATOR_PLATFORM AND MSVC_VERSION LESS 1920)
     set (_ARCH "x86")
   endif ()
 


### PR DESCRIPTION
In Visual Studio 2017 and earlier, if `CMAKE_GENERATOR_PLATFORM` was not specified, the build defaulted to 32-bit, hence `_ARCH` was to set to `x86` if `CMAKE_GENERATOR_PLATFORM` was not set with MSVC. However, since Visual Studio 2019 if `CMAKE_GENERATOR_PLATFORM` is not specified, the build defaults to 64-bit, see https://cmake.org/cmake/help/latest/generator/Visual%20Studio%2016%202019.html .

This patch ensure that 64-bit is correctly used for builds using Visual Studio 2019 and greater.