### PR TITLE
Fix macOS compile: add __ELF__ check for .note.GNU-stack

### DIFF
--- a/src/asm/trampoline-aarch64.S
+++ b/src/asm/trampoline-aarch64.S
@@ -77,4 +77,6 @@ ret_ctx:
 MANGLE(mmk_trampoline_end):
     nop
 
+#ifdef __ELF__
 .section  .note.GNU-stack, "", @progbits
+#endif

--- a/src/asm/trampoline-x86_64-systemv.S
+++ b/src/asm/trampoline-x86_64-systemv.S
@@ -104,4 +104,6 @@ ret_ctx:                                        // Return context
 MANGLE(mmk_trampoline_end):
     nop
 
+#ifdef __ELF__
 .section  .note.GNU-stack, "", @progbits
+#endif


### PR DESCRIPTION
Fix macOS build #27.

`.section  .note.GNU-stack, "", @progbits`, to make the stack not executable, is not compatible with Apple. The common way I found is checking for `__ELF__`.