### PR TITLE
When disabling optimization, also disable _FORTIFY_SOURCE

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -201,7 +201,7 @@ function (add_mimick_test _NAME)
 
   if (NOT MSVC)
     foreach (ARG ${ARGN})
-      set_source_files_properties (${ARG} PROPERTIES COMPILE_FLAGS -O0)
+      set_source_files_properties (${ARG} PROPERTIES COMPILE_FLAGS "-O0 -Wp,-U_FORTIFY_SOURCE")
     endforeach ()
   endif ()
 

--- a/sample/strdup/CMakeLists.txt
+++ b/sample/strdup/CMakeLists.txt
@@ -3,7 +3,7 @@ add_executable (strdup_test test.c)
 target_link_libraries (strdup_test strdup mimick)
 
 if (NOT MSVC)
-    set_source_files_properties (test.c PROPERTIES COMPILE_FLAGS -O0)
+    set_source_files_properties (test.c PROPERTIES COMPILE_FLAGS "-O0 -Wp,-U_FORTIFY_SOURCE")
 endif ()
 
 add_mimick_sample (strdup_test)


### PR DESCRIPTION
The _FORTIFY_SOURCE feature of gcc and clang cannot be enabled when optimization is disabled. When explicitly disabling it, also disable _FORTIFY_SOURCE if was externally enabled.

Submitted upstream as ros2/Mimick#33