### PR TITLE
 Find the symbols via DT_GNU_HASH instead of DT_HASH.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,7 @@
 # Redistribution and use of this file is allowed according to the terms of the MIT license.
 # For details see the LICENSE file distributed with Mimick.
 
-cmake_minimum_required (VERSION 2.8.12)
+cmake_minimum_required (VERSION 3.5)
 
 project (Mimick C CXX)
 # Default to C++11


### PR DESCRIPTION
Since glibc 2.36 (released in August 2022), builds of libc.so.6
are built with the default value of --hash-style on all platforms.
The immediate effect of this is that linker no longer generates
a DT_HASH section, which is what Mimick uses to detect vital
functions like vfprintf and abort.

It turns out that Ubuntu and Debian specifically override this
behavior on amd64 and i386, since there are some proprietary
applications on those platforms that depend on this.  However,
this override is *not* applied on aarch64, so there is no DT_HASH.
This explains the discrepancy we see when running CI on amd64
(where Mimick tests succeed) and aarch64 (where Mimick tests fail).

It also turns out that DT_HASH is "deprecated", and has been for
about 15 years.  Thus, all of our platforms (going back to RHEL-8)
support this construct.

Thus, this commit implements getting symbols from DT_GNU_HASH instead
of from DT_HASH.  Note that it also changes it so that we *prefer*
to get the data from DT_GNU_HASH, as someday DT_HASH may go away
entirely.

I should note that I borrowed heavily from
https://flapenguin.me/elf-dt-gnu-hash and
https://sourceware.org/git/?p=glibc.git;a=blob;f=elf/dl-lookup.c;h=3d2369dbf2b7ca219eaf80a820e2a8e1329fbf50;hb=HEAD#l350
to implement this, though I made a bunch of changes to fix
warnings and better integrate into the Mimick source code.