### PR TITLE
Fix compiling error when compile with mingw-ucrt64

### DIFF
--- a/src/vitals.c
+++ b/src/vitals.c
@@ -187,7 +187,7 @@ void mmk_init_vital_functions(plt_ctx ctx)
         mmk___stdio_common_vfprintf_ = (void *)
                 plt_get_real_fn(ctx, "__stdio_common_vfprintf");
         if (mmk___stdio_common_vfprintf_)
-            mmk_vfprintf_ = win32_vfprintf_fallback;
+            mmk_vfprintf_ = (void *)win32_vfprintf_fallback;
     }
 #endif
 


### PR DESCRIPTION
the original error message was:

```
/src/vitals.c:190:27: error: assignment to 'void (*)(FILE *, const char *, char *)' {aka 'void (*)(struct _iobuf *, const char *, char *)'} from incompatible pointer type 'int (*)(FILE *, const char *, char *)' {aka 'int (*)(struct _iobuf *, const char *, char *)'} [-Wincompatible-pointer-types]
  190 |             mmk_vfprintf_ = win32_vfprintf_fallback;
      |                           ^
```